### PR TITLE
Add Node.js release support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
 # packages it depends on, namespaces, and so forth.
 
 [options]
+# 🔮 TODO: packaging and github3.py are rather out of date; not causing problems now, just FYI
 install_requires =
     github3.py == 1.3.0  # Do not change this version without also changing it in github-actions-base
     lxml == 4.6.3        # Do not change this version without also changing it in github-actions-base
@@ -49,6 +50,7 @@ packages = find_namespace:
 python_requires = >= 3.9
 
 [options.extras_require]
+# 🔮 TODO: these should have pins (dependency confusion vulnerability)
 dev =
     black
     flake8
@@ -73,6 +75,7 @@ console_scripts =
     snapshot-release=lasso.releasers.maven_release:main
     maven-release=lasso.releasers.maven_release:main
     python-release=lasso.releasers.python_release:main
+    nodejs-release=lasso.releasers.nodejs_release:main
 
 
 [options.packages.find]

--- a/src/lasso/releasers/nodejs_release.py
+++ b/src/lasso/releasers/nodejs_release.py
@@ -1,0 +1,35 @@
+"""Node.js release automation."""
+import json
+import os
+
+
+from .release import release_publication
+
+SNAPSHOT_TAG_SUFFIX = "-unstable"
+
+
+def nodejs_get_version(workspace=None):
+    """Get the version out of the ``workspace``."""
+    workspace = workspace or os.environ.get("GITHUB_WORKSPACE")
+    package_path = os.path.join(workspace, "package.json")
+    with open(package_path, "r") as package_json_io:
+        metadata = json.load(package_json_io)
+        return metadata["version"]
+
+
+def nodejs_upload_assets(repo_name, tag_name, release):
+    """Upload Node.js assets.
+
+    This is a no-op since npm knows how to install from a GitHub release itself, so we just let
+    the GitHub release happen without any additional assets to upload.
+    """
+    pass
+
+
+def main():
+    """Entrypoint."""
+    release_publication(SNAPSHOT_TAG_SUFFIX, nodejs_get_version, nodejs_upload_assets)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lasso/releasers/nodejs_release.py
+++ b/src/lasso/releasers/nodejs_release.py
@@ -2,7 +2,6 @@
 import json
 import os
 
-
 from .release import release_publication
 
 SNAPSHOT_TAG_SUFFIX = "-unstable"

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,11 @@ deps = .[dev]
 whitelist_externals = pytest
 commands = pytest
 
-[testenv:docs]
-deps = .[dev]
-whitelist_externals = python
-commands = python setup.py build_sphinx
+# Disabled since there are actually no docs
+# [testenv:docs]
+# deps = .[dev]
+# whitelist_externals = python
+# commands = python setup.py build_sphinx
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
## 🗒️ Summary

Merge this to get Node.js support for GitHub releases.

## ⚙️ Test Data and/or Report
```console
$ tox -e py39
…
======================= 2 passed, 101 warnings in 2.04s ========================
___________________________________ summary ____________________________________
  py39: commands succeeded
  congratulations :)
$ nodejs-release --debug --token 'REDACTED' --repo_name nutjob4life/git-testing --workspace /tmp/test --snapshot
🪵 Setting log level to 10, debug happens to be 10
YO YO YO USING tag_name of «v0.0.0»
INFO Building a url from ('https://api.github.com', 'repos', 'nutjob4life', 'git-testing')
INFO Missed the cache building the url
…
INFO JSON was returned
INFO upload assets
$ echo 🎉
🎉
```

## ♻️ Related Issues

- #1 
