### PR TITLE
Upgrading to Python 3.13

### DIFF
--- a/.github/workflows/branch-cicd.yaml
+++ b/.github/workflows/branch-cicd.yaml
@@ -42,7 +42,7 @@ jobs:
                 name: Set up Python 3
                 uses: actions/setup-python@v5
                 with:
-                    python-version: '3.9'
+                    python-version: '3.13'
             -
                 name: 💵 Python Cache
                 uses: actions/cache@v3
@@ -58,6 +58,5 @@ jobs:
                 name: 🩺 Test Software
                 run:
                     pip install --editable '.[dev]'
-
                     tox
                 shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: .*\.(yaml|yml)$
 
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v3.15.0
     hooks:
     -   id: reorder-python-imports
         files: ^src/|tests/
@@ -27,14 +27,21 @@ repos:
 #         language: system
 #         pass_filenames: false
 
--   repo: local
-    hooks:
-    -   id: black
-        name: black
-        entry: black
-        files: ^src/|tests/
-        language: system
-        types: [python]
+# Disabling black because it's conflicting with reorder_python_imports. That
+# hook wants to add a blank line before the imports, and then black wants to
+# remove it.
+#
+# Choosing to prioritize reorder_python_imports hook since it can reduce
+# merge conflicts and black is too authoritarian.
+#
+# -   repo: local
+#     hooks:
+#     -   id: black
+#         name: black
+#         entry: black
+#         files: ^src/|tests/
+#         language: system
+#         types: [python]
 
 -   repo: local
     hooks:
@@ -50,7 +57,7 @@ repos:
         name: Tests
         entry: pytest
         language: system
-        stages: [push]
+        stages: [pre-push]
         pass_filenames: false
 
 # #65: support for git-secrets

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ classifiers =
 install_requires =
     github3.py == 4.0.1  # Do not change this version without also changing it in github-actions-base
     lxml == 6.0.0        # Do not change this version without also changing it in github-actions-base
-    packaging == 21.0
+    packaging ~= 25.0
 
 
 # Change this to False if you use things like __file__ or __path__—which you

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,7 @@ url = https://github.com/NASA-PDS/lasso-releasers
 download_url = https://github.com/NASA-PDS/lasso-releasers/releases/
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.13
     Operating System :: OS Independent
 
 
@@ -34,20 +33,19 @@ classifiers =
 [options]
 # 🔮 TODO: packaging and github3.py are rather out of date; not causing problems now, just FYI
 install_requires =
-    github3.py == 1.3.0  # Do not change this version without also changing it in github-actions-base
-    lxml == 4.6.3        # Do not change this version without also changing it in github-actions-base
-    packaging == 21.0    # Do not change this version without also changing it in github-actions-base
+    github3.py == 4.0.1  # Do not change this version without also changing it in github-actions-base
+    lxml == 6.0.0        # Do not change this version without also changing it in github-actions-base
+    packaging == 21.0
 
 
 # Change this to False if you use things like __file__ or __path__—which you
-# shouldn't use anyway, because that's what ``pkg_resources`` is for 🙂
+# shouldn't use anyway, because that's what ``importlib`` is for 🙂
 zip_safe = True
 include_package_data = True
-namespace_packages = lasso
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >= 3.9
+python_requires = >= 3.13
 
 [options.extras_require]
 # 🔮 TODO: these should have pins (dependency confusion vulnerability)

--- a/src/lasso/__init__.py
+++ b/src/lasso/__init__.py
@@ -1,4 +1,2 @@
 # encoding: utf-8
 """PDS "Lasso" 🤠 namespace."""
-
-__import__("pkg_resources").declare_namespace(__name__)

--- a/src/lasso/releasers/__init__.py
+++ b/src/lasso/releasers/__init__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
 """PDS Lasso Releasers."""
-import pkg_resources
+import importlib.resources
 
-__version__ = VERSION = pkg_resources.resource_string(__name__, "VERSION.txt").decode("utf-8").strip()
+__version__ = VERSION = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/src/lasso/releasers/_python_version.py
+++ b/src/lasso/releasers/_python_version.py
@@ -112,7 +112,7 @@ class TextFileDetective(VersionDetective):
         """Detect the version."""
         version_file = self.locate_file(self.workspace)
         if version_file is not None:
-            with open(version_file, "r") as inp:
+            with open(version_file, "r", encoding="utf-8") as inp:
                 return inp.read().strip()
         else:
             return None
@@ -166,7 +166,7 @@ class _SetupDetective(VersionDetective):
         if not setupfile:
             return None
         expr = self.getregexp()
-        with open(setupfile, "r") as inp:
+        with open(setupfile, "r", encoding="utf-8") as inp:
             for line in inp:
                 match = expr.search(line)
                 if match:
@@ -234,10 +234,10 @@ def getversion(workspace=None):
         if version:
             # Validate it
             try:
-                versionobj = packaging.version.parse(version)
-                if not isinstance(versionobj, packaging.version.LegacyVersion):
-                    # A newer and therefore better version, so add it
-                    versions.add(version)
+                # In Python 3.13+, LegacyVersion is removed, so we just check if parsing succeeded
+                # All valid versions are now Version objects, not LegacyVersion
+                _ = packaging.version.parse(version)
+                versions.add(version)
             except packaging.version.InvalidVersion:
                 # Invalid, we won't add it
                 pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -20,6 +20,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary

Upgrades from supporting Python 3.9 to Python 3.13.

## ⚙️ Test Data and/or Report

This tool is used by the Roundup Action. See successful Roundup runs at

- Stable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/16601184002
- Unstable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/14842393866

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105