### PR TITLE
Harden maven releases

### DIFF
--- a/src/lasso/releasers/maven_release.py
+++ b/src/lasso/releasers/maven_release.py
@@ -12,6 +12,7 @@ SNAPSHOT_TAG_SUFFIX = "SNAPSHOT"
 _logger = logging.getLogger(__name__)
 
 _mime_types = {
+    ".gz": "application/gzip",
     ".tar.gz": "application/gzip",
     ".zip": "application/zip",
     ".jar": "application/java-archive",

--- a/src/lasso/releasers/maven_release.py
+++ b/src/lasso/releasers/maven_release.py
@@ -1,13 +1,15 @@
 """Maven release automation."""
 import fnmatch
+import logging
 import os.path
-import sys
 
 from lxml import etree
 
 from .release import release_publication
 
 SNAPSHOT_TAG_SUFFIX = "SNAPSHOT"
+
+_logger = logging.getLogger(__name__)
 
 _mime_types = {
     ".tar.gz": "application/gzip",
@@ -27,13 +29,13 @@ def maven_get_version(workspace=None):
         namespaces={"pom": "http://maven.apache.org/POM/4.0.0"},
     )
     version = r[0].text
-    print(f"Yo yo maven gets version {version} from the pom", file=sys.stderr)
+    _logger.info("🔍 Maven gets version %s from the pom", version)
     return version
 
 
 def maven_upload_assets(repo_name, tag_name, release):
     """Upload packages produced by maven."""
-    print(f"Yo yo maven upload assets for {repo_name} and tag {tag_name}", file=sys.stderr)
+    _logger.info("🔍 Maven upload assets for %s and tag %s", repo_name, tag_name)
     # upload assets
     assets_found = False
     assets, workspace = ["*-bin.tar.gz", "*-bin.zip", "*.jar"], os.environ.get("GITHUB_WORKSPACE")

--- a/src/lasso/releasers/release.py
+++ b/src/lasso/releasers/release.py
@@ -63,6 +63,7 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
     except github3.GitHubError as error:
         print(f"‼️ Error creating release: {error}", file=sys.stderr)
         print(error.errors, file=sys.stderr)
+        raise RuntimeError(f"‼️ Error creating release: {error}")
 
 
 def delete_snapshot_releases(_repo, suffix):

--- a/src/lasso/releasers/release.py
+++ b/src/lasso/releasers/release.py
@@ -47,7 +47,12 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
 
     try:
         our_branch = repo.branch(branch_name)
+        print(
+            f"😱 START TO WORRY: Creating tag {tag_name} for branch {branch_name} with commit {our_branch.commit.sha}",
+            file=sys.stderr
+        )
         repo.create_tag(tag_name, "release", our_branch.commit.sha, "commit", tagger)
+        print("😮‍💨 END TO WORRY it worked", file=sys.stderr)
 
         # create the release
         release = repo.create_release(

--- a/src/lasso/releasers/release.py
+++ b/src/lasso/releasers/release.py
@@ -61,7 +61,8 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
         upload_assets(repo_name, tag_name, release)
 
     except github3.GitHubError as error:
-        _logger.error(error.errors)
+        print(f"‼️ Error creating release: {error}", file=sys.stderr)
+        print(error.errors, file=sys.stderr)
 
 
 def delete_snapshot_releases(_repo, suffix):
@@ -95,7 +96,8 @@ def create_snapshot_release(repo, repo_name, branch_name, tag_name, tagger, uplo
         upload_assets(repo_name, tag_name, release)
 
     except github3.exceptions.GitHubError as error:  # 💢
-        print(error.errors)
+        print(f"‼️ Error creating snapshot release: {error}", file=sys.stderr)
+        print(error.errors, file=sys.stderr)
 
 
 def release_publication(suffix, get_version, upload_assets, prefix="v"):
@@ -141,7 +143,6 @@ def release_publication(suffix, get_version, upload_assets, prefix="v"):
 
     gh = github3.login(token=token)
     repo = gh.repository(org, repo_name)
-
     delete_snapshot_releases(repo, suffix)
     if tag_name.endswith(suffix) or args.snapshot:
         if not tag_name.endswith(suffix):


### PR DESCRIPTION
## 🗒️ Summary

The last [ds-view stable release](https://github.com/NASA-PDS/ds-view/actions/runs/17782071669) failed to make the v2.22.5 release on [its release page](https://github.com/NASA-PDS/ds-view/releases). Looking at the Roundup log, it appears `maven-release` silently avoided doing anything and exited with success.

There are several problems:

- If none of the assets match the expected extensions, nothing happens and is treated as success
- If the target directory is missing, nothing happens and is treated as success
- `upload_asset` is called with `application/tar+gzip` as the MIME type for every file, even `.zip` files (should be `application/zip`) and `.jar` files (should be `application/java-archive`); GitHub has allowed mismatches in the past—maybe not anymore? 🤔
- GitHub exceptions merely get printed without context, often showing up as `[]` in the log 💢

This PR also:

- Replaces `print` statements with the logger
- Treats failures in tagging (`v1.2.3`, for example) as a soft error; the Roundup already does this, but separating this treatment out makes the process in lasso-releasers more robust when used standalone
- Treats converting the tag into a release and uploading artifacts as hard errors, resulting in non-zero exit status


## ⚙️ Test Data and/or Report

Successful ds-view stable release: https://github.com/NASA-PDS/ds-view/releases

❗️ **Important note**: we'll need to do one more stable release of ds-view after all this is said and done; I had commented out the Maven/Sonatype/Central Portal step while debugging to speed things up. Release 2.22.9 looks successful on GitHub but it's missing in the Sonatype Central Portal.


## ♻️ Related Issues

See [Slack conversation starting here](https://jpl.slack.com/archives/GCGR1R3A4/p1758067039449149)