### PR TITLE
Resolve roundup-action#155: source archives and tagged trees have corrected <version> in pom.xml

### DIFF
--- a/src/lasso/releasers/release.py
+++ b/src/lasso/releasers/release.py
@@ -43,7 +43,7 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
 
     Push the assets created in target directory.
     """
-    _logger.info("create new release")
+    _logger.info("🧐 create new release, repo_name: %s, branch_name: %s, tag_name: %s", repo_name, branch_name, tag_name)
 
     try:
         our_branch = repo.branch(branch_name)
@@ -57,14 +57,12 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
 
     try:
         # create the release
-        _logger.info('📀 Attempting to create release %s for branch %s', tag_name, branch_name)
+        _logger.info("𝌚 Creating release %s from tag %s", tag_name, tag_name)
         release = repo.create_release(
             tag_name,
-            target_commitish=branch_name,
             name=repo_name + " " + tag_name,
             prerelease=False,
         )
-
         _logger.info("⬆️ Uploading assets")
         upload_assets(repo_name, tag_name, release)
     except github3.GitHubError as error:


### PR DESCRIPTION
## 🗒️ Summary

Merge this to fix the problem when the Roundup Action was creating release pages with source `.tar.gz` and source `.zip` file artifacts as well as tagged trees with the previous version as `-SNAPSHOT` in `pom.xml`.

For example, if you did

    git tag --message release/1.2.0 release/1.2.0 && git push origin release/1.2.0

everything would seem to work. If you then visited the "Release" page for your repository, under "Release 1.2.0", if you downloaded the "Source code (zip)" or "Source code (tar.gz)" files, the `pom.xml` file would have
```xml
<version>1.1.0-SNAPSHOT</version>
```
appearing in it. The same would apply if you did a `git checkout v1.2.0` and opened the `pom.xml` in this "detached HEAD" state.

This PR fixes it—so long as you also merge the [matching PR in roundup-action](https://github.com/NASA-PDS/roundup-action/pull/156).


## ⚙️ Test Data and/or Report

I ran in the [exemplar repository](https://github.com/nasa-pds-engineering-node/exemplar/):
```console
$ cd exemplar
$ git tag --message release/7.1.0 release/7.1.0
$ git push origin release/7.1.0
```
And the Roundup log completed.

I then download the Source code artifacts from the [release v7.1.0 page](https://github.com/nasa-pds-engineering-node/exemplar/releases/tag/v7.1.0):
```console
$ cd /tmp
$ curl --silent -L 'https://github.com/nasa-pds-engineering-node/exemplar/archive/refs/tags/v7.1.0.tar.gz' | tar xzf -
$ egrep 'version>7' exemplar-7.1.0/pom.xml
    <version>7.1.0</version>
$ rm -rf exemplar-7.1.0
$ curl --silent -LO 'https://github.com/nasa-pds-engineering-node/exemplar/archive/refs/tags/v7.1.0.zip'
$ unzip -qq v7.1.0.zip
$ egrep 'version>7' exemplar-7.1.0/pom.xml 
    <version>7.1.0</version>
```
Finally I checked the `v7.1.0` tag:
```console
$ cd exemplar
$ git fetch
$ git checkout v7.1.0
$ egrep 'version>7' pom.xml 
    <version>7.1.0</version>
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/roundup-action/issues/155
